### PR TITLE
Εμφάνιση εντολών πριν την εκτέλεση (Fix #45)

### DIFF
--- a/archon.sh
+++ b/archon.sh
@@ -11,6 +11,16 @@
 # Please read the file LICENSE, README and AUTHORS for more information.
 #
 #
+trap print_command DEBUG
+
+function print_command {
+	if [[ $BASH_COMMAND != echo* &&
+		  $BASH_COMMAND != sleep* &&
+		  $BASH_COMMAND != YN_Q* &&
+		  $BASH_COMMAND != read* ]]; then
+		echo "--- $BASH_COMMAND"
+	fi
+}
 
 
 function chroot_stage {


### PR DESCRIPTION
Τυπώνει κάθε εντολή πριν την εκτελέσει εκτός και αν δεν έχει και τόσο ουσία όπως echo, sleep, read, κλπ.
Για αρχή το αφήνω ως default αλλά στο μέλλον καλύτερα θα ήταν να το ενεργοποιούσε με μια παράμετρο.