### PR TITLE
Επιλογή GPT για BIOS συστήματα, και επιλογή filesystem

### DIFF
--- a/archon.sh
+++ b/archon.sh
@@ -326,10 +326,31 @@ else
 	echo " Χρησιμοποιείς PC με BIOS";
 	echo
 	sleep 1
-	parted "$diskvar" mklabel msdos
-	parted "$diskvar" mkpart primary ext4 1MiB 100%
-	mkfs.ext4 "$diskvar""1"
-	mount "$diskvar""1" "/mnt"
+#							Υποστηριξη GPT για BIOS συστήματα
+	PS0001="Θα θέλατε GPT Partition scheme or MBR(MSDOS)?"
+	options=("MBR(MSDOS)" "GPT")
+	select opt in "${options[@]}"
+	do
+		case $opt in
+			"MBR(MSDOS)")
+				parted "$diskvar" mklabel msdos
+				parted "$diskvar" mkpart primary ext4 1MiB 100%
+				mkfs.ext4 "$diskvar""1"
+				mount "$diskvar""1" "/mnt"
+				break
+				;;
+			"GPT")
+				parted "$diskvar" mklabel gpt
+				parted "$diskvar" mkpart primary 1 3
+				parted "$diskvar" set 1 bios_grub on
+				parted "$diskvar" mkpart primary ext4 100%
+				mkfs.ext4 "$diskvar""2"
+				mount "$diskvar""2" "/mnt"
+				break
+				;;
+			*) echo "invalid option $Reply";;
+		esac
+	done
 fi
 sleep 1
 echo

--- a/archon.sh
+++ b/archon.sh
@@ -326,8 +326,8 @@ else
 	echo " Χρησιμοποιείς PC με BIOS";
 	echo
 	sleep 1
-#							Υποστηριξη GPT για BIOS συστήματα
-	PS0001="Θα θέλατε GPT Partition scheme or MBR(MSDOS)?"
+################### Υποστηριξη GPT για BIOS συστήματα #####################							
+PS0001="Θα θέλατε GPT Partition scheme or MBR(MSDOS)?"
 	options=("MBR(MSDOS)" "GPT")
 	select opt in "${options[@]}"
 	do

--- a/archon.sh
+++ b/archon.sh
@@ -326,8 +326,8 @@ else
 	echo " Χρησιμοποιείς PC με BIOS";
 	echo
 	sleep 1
-#							Υποστηριξη GPT για BIOS συστήματα
-	PS0001="Θα θέλατε GPT Partition scheme or MBR(MSDOS)?"
+	################### Υποστηριξη GPT για BIOS συστήματα #####################	
+	PS0001="Θα θέλατε GPT Partition scheme ή MBR(MSDOS)?"
 	options=("MBR(MSDOS)" "GPT")
 	select opt in "${options[@]}"
 	do


### PR DESCRIPTION
Προσθήκη για XFS,Btrfs,F2FS για UEFI και BIOS συστήματα. Στα BIOS είναι 1 partition που θα φορμαριστει. Σε UEFI συστηματα παραμένει το FAT32 partition για το  /boot, (αναγκαστικά). Επισης για τα BIOS συστήματα μπορούμε να έχουμε GPT scheme, αφήνοντας 2M στην αρχή, για το BIOS_boot.